### PR TITLE
test: exercise all agent invocation paths

### DIFF
--- a/tests/integration/agent-invocation.integration.test.ts
+++ b/tests/integration/agent-invocation.integration.test.ts
@@ -78,4 +78,94 @@ describe('Agent Invocation Integration Tests', () => {
     expect(response.jsonrpc).toBe('2.0');
     expect(response.result).toBeDefined();
   });
+
+  it('should invoke backend agent', async () => {
+    const response = await client.call('tools/call', {
+      name: 'mcp__levys-awesome-mcp__mcp__agent-invoker__invoke_agent',
+      arguments: {
+        agentName: 'backend-agent',
+        prompt: 'Test backend agent',
+        maxTurns: 1
+      }
+    });
+
+    expect(response.jsonrpc).toBe('2.0');
+    expect(response.result).toBeDefined();
+    expect(response.result.content).toBeDefined();
+  });
+
+  it('should invoke frontend agent', async () => {
+    const response = await client.call('tools/call', {
+      name: 'mcp__levys-awesome-mcp__mcp__agent-invoker__invoke_agent',
+      arguments: {
+        agentName: 'frontend-agent',
+        prompt: 'Test frontend agent',
+        maxTurns: 1
+      }
+    });
+
+    expect(response.jsonrpc).toBe('2.0');
+    expect(response.result).toBeDefined();
+    expect(response.result.content).toBeDefined();
+  });
+
+  it('should invoke builder agent', async () => {
+    const response = await client.call('tools/call', {
+      name: 'mcp__levys-awesome-mcp__mcp__agent-invoker__invoke_agent',
+      arguments: {
+        agentName: 'builder-agent',
+        prompt: 'Test builder agent',
+        maxTurns: 1
+      }
+    });
+
+    expect(response.jsonrpc).toBe('2.0');
+    expect(response.result).toBeDefined();
+    expect(response.result.content).toBeDefined();
+  });
+
+  it('should invoke linter agent', async () => {
+    const response = await client.call('tools/call', {
+      name: 'mcp__levys-awesome-mcp__mcp__agent-invoker__invoke_agent',
+      arguments: {
+        agentName: 'linter',
+        prompt: 'Test linter agent',
+        maxTurns: 1
+      }
+    });
+
+    expect(response.jsonrpc).toBe('2.0');
+    expect(response.result).toBeDefined();
+    expect(response.result.content).toBeDefined();
+  });
+
+  it('should invoke orchestrator agent', async () => {
+    const response = await client.call('tools/call', {
+      name: 'mcp__levys-awesome-mcp__mcp__agent-invoker__invoke_agent',
+      arguments: {
+        agentName: 'orchestrator',
+        prompt: 'Test orchestrator agent',
+        maxTurns: 1
+      }
+    });
+
+    expect(response.jsonrpc).toBe('2.0');
+    expect(response.result).toBeDefined();
+    expect(response.result.content).toBeDefined();
+  });
+
+  it('should invoke planner agent', async () => {
+    const response = await client.call('tools/call', {
+      name: 'mcp__levys-awesome-mcp__mcp__agent-invoker__invoke_agent',
+      arguments: {
+        agentName: 'planner',
+        prompt: 'Test planner agent',
+        maxTurns: 1
+      }
+    });
+
+    expect(response.jsonrpc).toBe('2.0');
+    expect(response.result).toBeDefined();
+    expect(response.result.content).toBeDefined();
+  });
 });


### PR DESCRIPTION
## Summary
- expand integration coverage by invoking backend, frontend, builder, linter, orchestrator, and planner agents
- verify each agent returns a JSON-RPC result with minimal content

## Testing
- `npm test tests/integration/agent-invocation.integration.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bd63567a8c8324a8b5548fde411cab