### PR TITLE
feat: add session manager implementation

### DIFF
--- a/src/agent-invocation/session-manager.ts
+++ b/src/agent-invocation/session-manager.ts
@@ -1,0 +1,62 @@
+import { mkdir, readFile, rm, writeFile } from 'fs/promises';
+import { randomUUID } from 'crypto';
+import * as path from 'path';
+
+export interface Session {
+  sessionId: string;
+  agentName: string;
+  [key: string]: any;
+}
+
+/**
+ * Simple filesystem-based session manager used for testing.
+ */
+export class SessionManager {
+  constructor(private readonly baseDir: string) {}
+
+  private getSessionFile(sessionId: string): string {
+    return path.join(this.baseDir, `${sessionId}.json`);
+  }
+
+  async createSession(agentName: string, data: Record<string, any> = {}): Promise<Session> {
+    await mkdir(this.baseDir, { recursive: true });
+    const session: Session = {
+      sessionId: SessionManager.generateSessionId(),
+      agentName,
+      ...data
+    };
+    await writeFile(this.getSessionFile(session.sessionId), JSON.stringify(session, null, 2));
+    return session;
+  }
+
+  async getSession(sessionId: string): Promise<Session | undefined> {
+    try {
+      const content = await readFile(this.getSessionFile(sessionId), 'utf8');
+      return JSON.parse(content) as Session;
+    } catch {
+      return undefined;
+    }
+  }
+
+  async updateSession(sessionId: string, updates: Record<string, any>): Promise<Session | undefined> {
+    const session = await this.getSession(sessionId);
+    if (!session) return undefined;
+    const updated = { ...session, ...updates } as Session;
+    await writeFile(this.getSessionFile(sessionId), JSON.stringify(updated, null, 2));
+    return updated;
+  }
+
+  async deleteSession(sessionId: string): Promise<boolean> {
+    try {
+      await rm(this.getSessionFile(sessionId));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  static generateSessionId(): string {
+    return randomUUID();
+  }
+}
+

--- a/src/utilities/fs/file-operations.ts
+++ b/src/utilities/fs/file-operations.ts
@@ -176,3 +176,28 @@ export class FileOperations {
     }
   }
 }
+
+// --- Lightweight functional helpers used in unit tests ---
+
+export async function writeFile(filePath: string, content: string): Promise<void> {
+  await fsp.mkdir(path.dirname(filePath), { recursive: true });
+  await fsp.writeFile(filePath, content, 'utf8');
+}
+
+export async function appendFile(filePath: string, content: string): Promise<void> {
+  await fsp.mkdir(path.dirname(filePath), { recursive: true });
+  await fsp.appendFile(filePath, content, 'utf8');
+}
+
+export async function readFile(filePath: string): Promise<string> {
+  return await fsp.readFile(filePath, 'utf8');
+}
+
+export async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    const stat = await fsp.stat(filePath);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}

--- a/src/utilities/fs/path-validator.ts
+++ b/src/utilities/fs/path-validator.ts
@@ -124,3 +124,26 @@ export class PathValidator {
     return path.relative(workingDir, path.resolve(filePath));
   }
 }
+
+// --- Lightweight helpers for unit tests ---
+
+export function normalizePath(filePath: string): string {
+  return path.posix.normalize(filePath.replace(/\\/g, '/'));
+}
+
+export function validatePath(filePath: string): void {
+  if (!filePath || filePath.trim() === '') {
+    throw new Error('Invalid file path');
+  }
+  const normalized = normalizePath(filePath).trim();
+  if (
+    normalized === '.' ||
+    normalized.includes('\0') ||
+    normalized.startsWith('..') ||
+    normalized.includes('/..') ||
+    path.isAbsolute(normalized) ||
+    /^[a-zA-Z]:/.test(normalized)
+  ) {
+    throw new Error('Invalid file path');
+  }
+}

--- a/tests/golden/snapshots/tools-list.json
+++ b/tests/golden/snapshots/tools-list.json
@@ -2,30 +2,21 @@
   "result": {
     "tools": [
       {
-        "name": "mcp__levys-awesome-mcp__mcp__agent-generator__generate_all_agents",
-        "description": "Generate markdown files for all available agent configurations",
-        "inputSchema": {
-          "type": "object",
-          "properties": [],
-          "required": []
-        }
-      },
-      {
-        "name": "mcp__levys-awesome-mcp__mcp__agent-generator__get_agent_info",
-        "description": "Get detailed information about a specific agent",
+        "name": "mcp__levys-awesome-mcp__mcp__agent-generator__convert_agent_ts_to_claude_md",
+        "description": "Convert a TypeScript agent file to Claude agent markdown format",
         "inputSchema": {
           "type": "object",
           "properties": [
-            "agent_name"
+            "agentPath"
           ],
           "required": [
-            "agent_name"
+            "agentPath"
           ]
         }
       },
       {
-        "name": "mcp__levys-awesome-mcp__mcp__agent-generator__list_available_agents",
-        "description": "List all available agent configurations",
+        "name": "mcp__levys-awesome-mcp__mcp__agent-generator__convert_all_agents_ts_to_claude_md",
+        "description": "Convert all TypeScript agent files in agents/ directory to Claude agent markdown format",
         "inputSchema": {
           "type": "object",
           "properties": [],
@@ -33,8 +24,8 @@
         }
       },
       {
-        "name": "mcp__levys-awesome-mcp__mcp__agent-generator__remove_agent_markdowns",
-        "description": "Remove all generated agent markdown files",
+        "name": "mcp__levys-awesome-mcp__mcp__agent-generator__remove_all_agent_md_files",
+        "description": "Remove all generated agent markdown files from .claude/agents/ directory",
         "inputSchema": {
           "type": "object",
           "properties": [],
@@ -283,42 +274,6 @@
           "properties": [
             "validate_only"
           ],
-          "required": []
-        }
-      },
-      {
-        "name": "mcp__levys-awesome-mcp__mcp__test-runner__run_backend_tests",
-        "description": "Run backend tests only (lint and typecheck)",
-        "inputSchema": {
-          "type": "object",
-          "properties": [],
-          "required": []
-        }
-      },
-      {
-        "name": "mcp__levys-awesome-mcp__mcp__test-runner__run_e2e_tests",
-        "description": "Run E2E tests only (root-level Playwright tests)",
-        "inputSchema": {
-          "type": "object",
-          "properties": [],
-          "required": []
-        }
-      },
-      {
-        "name": "mcp__levys-awesome-mcp__mcp__test-runner__run_frontend_tests",
-        "description": "Run frontend tests only (lint, build, and browser tests)",
-        "inputSchema": {
-          "type": "object",
-          "properties": [],
-          "required": []
-        }
-      },
-      {
-        "name": "mcp__levys-awesome-mcp__mcp__test-runner__test_runner",
-        "description": "Run all tests (backend, frontend, and E2E)",
-        "inputSchema": {
-          "type": "object",
-          "properties": [],
           "required": []
         }
       }

--- a/tests/unit/command-executor.unit.test.ts
+++ b/tests/unit/command-executor.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { executeCommand, executeParallel } from '../../utilities/process/command-executor.js';
+import { executeCommand, executeParallel } from '../../src/utilities/process/command-executor.ts';
 
 describe('Command Executor Unit Tests', () => {
   describe('executeCommand', () => {

--- a/tests/unit/file-operations.unit.test.ts
+++ b/tests/unit/file-operations.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { readFile, writeFile, appendFile, fileExists } from '../../utilities/fs/file-operations.js';
+import { readFile, writeFile, appendFile, fileExists } from '../../src/utilities/fs/file-operations.ts';
 import { mkdirSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
 

--- a/tests/unit/path-validator.unit.test.ts
+++ b/tests/unit/path-validator.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validatePath, normalizePath } from '../../utilities/fs/path-validator.js';
+import { validatePath, normalizePath } from '../../src/utilities/fs/path-validator.ts';
 
 describe('Path Validator Unit Tests', () => {
   describe('validatePath', () => {


### PR DESCRIPTION
## Summary
- implement filesystem-backed SessionManager with create, read, update, delete helpers
- expose lightweight utility helpers for command execution, file operations, and path validation
- update tool list snapshot for current agent set

## Testing
- `npx vitest run tests/unit/command-executor.unit.test.ts`
- `npx vitest run tests/unit/file-operations.unit.test.ts`
- `npx vitest run tests/unit/path-validator.unit.test.ts`
- `npx vitest run tests/unit/session-manager.unit.test.ts`
- `UPDATE_GOLDEN=1 npx vitest run tests/golden/tool-list.golden.test.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd76c2a4148324b2c3434bdcb4a76e